### PR TITLE
feat: add emotion-based AR views

### DIFF
--- a/src/app/app.component.css
+++ b/src/app/app.component.css
@@ -17,4 +17,4 @@
   box-shadow: 0 4px 14px rgba(0,0,0,.15);
 }
 
-.app-main { min-height: calc(100dvh - 56px); }
+.app-main { min-height: calc(100dvh - 56px); }

--- a/src/app/features/ar-viewer/ar-viewer.component.html
+++ b/src/app/features/ar-viewer/ar-viewer.component.html
@@ -9,9 +9,7 @@
   <video id="video" autoplay playsinline muted class="invisible absolute inset-0 w-full h-full object-cover"></video>
 
   <!-- Audio de fondo -->
-  <audio id="backgroundAudio" preload="auto" playsinline>
-    <source src="assets/audio/Ansiedad1.mp3" type="audio/mpeg" />
-  </audio>
+  <audio id="backgroundAudio" preload="auto" playsinline></audio>
 
   <!-- Botón para activar sonido (sin *ngIf para evitar CommonModule) -->
  

--- a/src/app/features/ar-viewer/ar-viewer.component.ts
+++ b/src/app/features/ar-viewer/ar-viewer.component.ts
@@ -1,5 +1,6 @@
 import { Component, OnInit, AfterViewInit, OnDestroy } from '@angular/core';
 import { Location } from '@angular/common';
+import { ActivatedRoute } from '@angular/router';
 import * as THREE from 'three';
 
 declare var SelfieSegmentation: any;
@@ -15,6 +16,9 @@ export class ArViewerComponent implements OnInit, AfterViewInit, OnDestroy {
   private canvas!: HTMLCanvasElement;
   private ctx!: CanvasRenderingContext2D | null;
   private audio!: HTMLAudioElement;
+
+  private imageUrl = '/assets/imagenes/ansiedad1.png';
+  private audioUrl = '/assets/audio/Ansiedad1.mp3';
 
   private selfieSegmentation: any;
   private stream: MediaStream | null = null;
@@ -40,10 +44,35 @@ export class ArViewerComponent implements OnInit, AfterViewInit, OnDestroy {
   private unlockAudioBound?: () => void;
   public hideEnableButton = false; // para ocultar botón tras habilitar sonido
 
-  constructor(private location: Location) {}
+  constructor(private location: Location, private route: ActivatedRoute) {}
 
   ngOnInit(): void {
-    // No tocar DOM aquí
+    this.route.queryParamMap.subscribe(params => {
+      const emotion = (params.get('emotion') || '').toLowerCase();
+      const assets: Record<string, { image: string; audio: string }> = {
+        ansiedad: {
+          image: '/assets/imagenes/ansiedad1.png',
+          audio: '/assets/audio/Ansiedad1.mp3'
+        },
+        tristeza: {
+          image: '/assets/imagenes/depresion1.png',
+          audio: '/assets/audio/depresion1.mp3'
+        },
+        estres: {
+          image: '/assets/imagenes/Estres.jpg',
+          audio: '/assets/audio/estres1.mp3'
+        }
+      };
+
+      if (assets[emotion]) {
+        this.imageUrl = assets[emotion].image;
+        this.audioUrl = assets[emotion].audio;
+      } else {
+        // por defecto
+        this.imageUrl = assets['ansiedad'].image;
+        this.audioUrl = assets['ansiedad'].audio;
+      }
+    });
   }
 
   ngAfterViewInit(): void {
@@ -73,10 +102,8 @@ export class ArViewerComponent implements OnInit, AfterViewInit, OnDestroy {
     // El canvas de segmentación NO debe bloquear drag/touch del 360
     this.canvas.style.pointerEvents = 'none';
 
-    // Configurar audio (ruta recomendada en Angular)
-    if (!this.audio.src) {
-      this.audio.src = '/audio/Ansiedad1.mp3';
-    }
+    // Configurar audio según la emoción detectada
+    this.audio.src = this.audioUrl;
     this.audio.loop = true;
     this.audio.preload = 'auto';
 
@@ -133,10 +160,9 @@ export class ArViewerComponent implements OnInit, AfterViewInit, OnDestroy {
     geometry.scale(-1, 1, 1);
 
     const loader = new THREE.TextureLoader();
-    const imageUrl = '/imagenes/img1.jpg'; // ¡importante! usar assets/...
 
     loader.load(
-      imageUrl,
+      this.imageUrl,
       (texture) => {
         texture.wrapS = THREE.RepeatWrapping;
         texture.repeat.x = -1; // invierte si lo ves al revés

--- a/src/app/features/generar-chat/generar-chat.component.ts
+++ b/src/app/features/generar-chat/generar-chat.component.ts
@@ -27,6 +27,8 @@ export class GenerarChatComponent implements OnInit {
     { sender: 'bot', text: 'Hola, soy Emonical! ¿En qué puedo ayudarte?' }
   ];
 
+  private detectedEmotion: string | null = null;
+
   constructor(private generarChatService: GenerarChatService, private router: Router) {}
 
   ngOnInit(): void {}
@@ -35,6 +37,9 @@ export class GenerarChatComponent implements OnInit {
     if (this.prompt.trim()) {
       // Agregar mensaje del usuario al array de mensajes
       this.messages.push({ sender: 'user', text: this.prompt });
+
+      // Detectar emoción en el mensaje del usuario
+      this.detectedEmotion = this.detectEmotion(this.prompt);
 
       // Llamar al servicio para obtener la respuesta del bot
       this.generarChatService.getContent(this.prompt).subscribe(
@@ -67,8 +72,28 @@ export class GenerarChatComponent implements OnInit {
     return match ? match[1] : 'Ejercicio';
   }
 
+  // Detecta palabras clave para identificar emociones
+  private detectEmotion(text: string): string | null {
+    const lower = text.toLowerCase();
+    const sadness = ['triste', 'tristeza', 'deprimido', 'depresión', 'depresion'];
+    const anxiety = ['ansiedad', 'ansioso', 'ansiosa', 'miedo'];
+    const stress = ['estrés', 'estres', 'estresado', 'estresada', 'agobiado', 'agobiada'];
+
+    if (sadness.some(w => lower.includes(w))) {
+      return 'tristeza';
+    }
+    if (anxiety.some(w => lower.includes(w))) {
+      return 'ansiedad';
+    }
+    if (stress.some(w => lower.includes(w))) {
+      return 'estres';
+    }
+    return null;
+  }
+
   // Función para abrir el componente de AR
   openAR(exerciseName: string): void {
-    this.router.navigate(['/ar-viewer'], { queryParams: { exercise: exerciseName } });
+    const emotion = this.detectedEmotion || 'ansiedad';
+    this.router.navigate(['/ar-viewer'], { queryParams: { exercise: exerciseName, emotion } });
   }
 }


### PR DESCRIPTION
## Summary
- detect sadness, anxiety, and stress keywords in chat and pass emotion to AR viewer
- load emotion-specific 360 images and audio in AR viewer with default fallback
- clean CSS invalid characters to resolve build issues

## Testing
- `npm test` *(fails: No binary for Chrome browser on your platform)*

------
https://chatgpt.com/codex/tasks/task_e_68ba0934d740832387b0c92e61cb416c