### PR TITLE
Enhance AR viewer design and fix sadness audio path

### DIFF
--- a/src/app/features/ar-viewer/ar-viewer.component.css
+++ b/src/app/features/ar-viewer/ar-viewer.component.css
@@ -1,6 +1,7 @@
 .ar-container {
   text-align: center;
   margin-top: 20px;
+  background: linear-gradient(180deg, #dbeafe 0%, #ffffff 100%);
 }
 
 /* Asegurar que el canvas mantenga la proporción correcta */
@@ -10,7 +11,7 @@
 
 /* Optimizaciones para el viewer 360 */
 #viewer360 {
-  background-color: #000;
+  background: linear-gradient(135deg, #93c5fd 0%, #ffffff 100%);
 }
 
 /* Ocultar controles de MediaPipe si aparecen */

--- a/src/app/features/ar-viewer/ar-viewer.component.html
+++ b/src/app/features/ar-viewer/ar-viewer.component.html
@@ -1,4 +1,4 @@
-<div class="relative w-screen h-screen overflow-hidden bg-black">
+<div class="relative w-screen h-screen overflow-hidden bg-gradient-to-br from-blue-100 via-white to-blue-300">
   <!-- Visor 360: Three.js inyecta su canvas aquí -->
   <div id="viewer360" class="absolute inset-0 z-0"></div>
 
@@ -16,7 +16,7 @@
 
   <!-- Botón regresar -->
   <button (click)="goBack()"
-          class="absolute top-4 left-4 bg-blue-500 hover:bg-blue-600 text-white px-4 py-2 rounded-md z-20">
+          class="absolute top-4 left-4 bg-white text-blue-700 border border-blue-500 hover:bg-blue-50 px-4 py-2 rounded-md shadow-md z-20">
     Regresar
   </button>
 </div>

--- a/src/app/features/ar-viewer/ar-viewer.component.ts
+++ b/src/app/features/ar-viewer/ar-viewer.component.ts
@@ -56,7 +56,7 @@ export class ArViewerComponent implements OnInit, AfterViewInit, OnDestroy {
         },
         tristeza: {
           image: '/imagenes/depresion1.png',
-          audio: '/assets/audio/depresion1.mp3'
+          audio: '/audio/depresion1.mp3'
         },
         estres: {
           image: '/imagenes/Estres.jpg',


### PR DESCRIPTION
## Summary
- correct tristeza audio path to /audio/depresion1.mp3
- apply blue-white gradient styling to AR viewer interface

## Testing
- `npm test -- --watch=false --progress=false` *(fails: No binary for Chrome browser on your platform)*

------
https://chatgpt.com/codex/tasks/task_e_68ba15b1c7ac83239795ab2e6a1ec76b