### PR TITLE
Enhance AR viewer design and add animated chat backdrop

### DIFF
--- a/src/app/features/ar-viewer/ar-viewer.component.css
+++ b/src/app/features/ar-viewer/ar-viewer.component.css
@@ -1,6 +1,7 @@
 .ar-container {
   text-align: center;
   margin-top: 20px;
+  background: linear-gradient(180deg, #dbeafe 0%, #ffffff 100%);
 }
 
 /* Asegurar que el canvas mantenga la proporción correcta */
@@ -10,7 +11,7 @@
 
 /* Optimizaciones para el viewer 360 */
 #viewer360 {
-  background-color: #000;
+  background: linear-gradient(135deg, #93c5fd 0%, #ffffff 100%);
 }
 
 /* Ocultar controles de MediaPipe si aparecen */

--- a/src/app/features/ar-viewer/ar-viewer.component.html
+++ b/src/app/features/ar-viewer/ar-viewer.component.html
@@ -1,4 +1,4 @@
-<div class="relative w-screen h-screen overflow-hidden bg-black">
+<div class="relative w-screen h-screen overflow-hidden bg-gradient-to-br from-blue-100 via-white to-blue-300">
   <!-- Visor 360: Three.js inyecta su canvas aquí -->
   <div id="viewer360" class="absolute inset-0 z-0"></div>
 
@@ -16,7 +16,7 @@
 
   <!-- Botón regresar -->
   <button (click)="goBack()"
-          class="absolute top-4 left-4 bg-blue-500 hover:bg-blue-600 text-white px-4 py-2 rounded-md z-20">
+          class="absolute top-4 left-4 bg-white text-blue-700 border border-blue-500 hover:bg-blue-50 px-4 py-2 rounded-md shadow-md z-20">
     Regresar
   </button>
 </div>

--- a/src/app/features/ar-viewer/ar-viewer.component.ts
+++ b/src/app/features/ar-viewer/ar-viewer.component.ts
@@ -56,7 +56,7 @@ export class ArViewerComponent implements OnInit, AfterViewInit, OnDestroy {
         },
         tristeza: {
           image: '/imagenes/depresion1.png',
-          audio: '/assets/audio/depresion1.mp3'
+          audio: '/audio/depresion1.mp3'
         },
         estres: {
           image: '/imagenes/Estres.jpg',

--- a/src/app/features/generar-chat/generar-chat.component.css
+++ b/src/app/features/generar-chat/generar-chat.component.css
@@ -2,4 +2,23 @@
     margin-left: 16rem; /* Ajusta el valor según el ancho de tu menú lateral */
     padding: 2rem;
   }
+
+.silhouette {
+  width: 60%;
+  max-width: 500px;
+  aspect-ratio: 1;
+  border-radius: 50%;
+  background: radial-gradient(circle at center, rgba(59,130,246,0.35), rgba(59,130,246,0.05) 60%, rgba(255,255,255,0) 80%);
+  filter: blur(80px);
+  animation: float 8s ease-in-out infinite alternate;
+}
+
+@keyframes float {
+  from {
+    transform: translateY(-10%);
+  }
+  to {
+    transform: translateY(10%);
+  }
+}
  

--- a/src/app/features/generar-chat/generar-chat.component.html
+++ b/src/app/features/generar-chat/generar-chat.component.html
@@ -21,28 +21,31 @@
    
 
     <!-- LISTA DE MENSAJES: apariencia minimal, misma lógica -->
-    <div class="px-4 sm:px-10 pb-10">
-      <div class="mx-auto max-w-3xl space-y-3">
-        <div *ngFor="let msg of messages" 
-             class="flex"
-             [ngClass]="{'justify-start': msg.sender === 'bot', 'justify-end': msg.sender === 'user'}">
-          <div
-            class="max-w-[80%] rounded-2xl px-4 py-2 shadow-sm ring-1 backdrop-blur
-                   text-sm sm:text-base"
-            [ngClass]="{
-              'bg-white/70 text-gray-800 ring-gray-200': msg.sender === 'user',
-              'bg-white/60 text-gray-700 ring-gray-200': msg.sender === 'bot'
-            }">
-            <p class="leading-relaxed">{{ msg.text }}</p>
-            <p *ngIf="msg.isExercise" class="mt-1">
-              
-              <a (click)="openAR(msg.exerciseName!)"
-                 class="text-indigo-600 underline cursor-pointer">{{ msg.exerciseName }}</a>.
-            </p>
+    <div class="px-4 sm:px-10 pb-10 relative">
+        <div class="absolute inset-0 flex items-center justify-center pointer-events-none -z-10">
+          <div class="silhouette"></div>
+        </div>
+        <div class="mx-auto max-w-3xl space-y-3">
+          <div *ngFor="let msg of messages"
+               class="flex"
+               [ngClass]="{'justify-start': msg.sender === 'bot', 'justify-end': msg.sender === 'user'}">
+            <div
+              class="max-w-[80%] rounded-2xl px-4 py-2 shadow-sm ring-1 backdrop-blur
+                     text-sm sm:text-base"
+              [ngClass]="{
+                'bg-white/70 text-gray-800 ring-gray-200': msg.sender === 'user',
+                'bg-white/60 text-gray-700 ring-gray-200': msg.sender === 'bot'
+              }">
+              <p class="leading-relaxed">{{ msg.text }}</p>
+              <p *ngIf="msg.isExercise" class="mt-1">
+
+                <a (click)="openAR(msg.exerciseName!)"
+                   class="text-indigo-600 underline cursor-pointer">{{ msg.exerciseName }}</a>.
+              </p>
+            </div>
           </div>
         </div>
       </div>
-    </div>
 
     
    


### PR DESCRIPTION
## Summary
- correct tristeza audio path to /audio/depresion1.mp3
- apply blue-white gradient styling to AR viewer interface
- add animated blue-gradient silhouette behind chat conversation

## Testing
- `npm test -- --watch=false --progress=false` *(fails: No binary for Chrome browser on your platform)*

------
https://chatgpt.com/codex/tasks/task_e_68ba15b1c7ac83239795ab2e6a1ec76b